### PR TITLE
chore: mark unused functions as deprecated

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -1087,6 +1087,8 @@ export function overrideOpacity(color: string, opacity: number): string {
 
 /**
  * Convert RGB <0, 255> into hex color string.
+ * 
+ * @deprecated
  *
  * @param red - Red channel.
  * @param green - Green channel.
@@ -1095,6 +1097,7 @@ export function overrideOpacity(color: string, opacity: number): string {
  * @returns Hex color string (for example: '#0acdc0').
  */
 export function RGBToHex(red: number, green: number, blue: number): string {
+  console.warn(`vis-util.RGBToHex is deprecated and will be removed in the next major release`);
   return '#' + ((1 << 24) + (red << 16) + (green << 8) + blue).toString(16).slice(1)
 }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -150,11 +150,14 @@ export function isDate(value: unknown): value is Date | string {
  * Test whether given object is a Moment date.
  * @TODO: This is basically a workaround, if Moment was imported property it wouldn't necessary as moment.isMoment is a TS type guard.
  *
+ * @deprecated
+ * 
  * @param value - Input value of unknown type.
  *
  * @returns True if Moment instance, false otherwise.
  */
 export function isMoment(value: unknown): value is Moment {
+  console.warn(`vis-util.isMoment is deprecated and will be removed in the next major release`);
   return moment.isMoment(value)
 }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -163,6 +163,8 @@ export function isMoment(value: unknown): value is Moment {
  * If property in b explicitly set to null, delete it if `allowDeletion` set.
  *
  * Internal helper routine, should not be exported. Not added to `exports` for that reason.
+ * 
+ * @deprecated
  *
  * @param a - Target object.
  * @param b - Source object.
@@ -170,6 +172,7 @@ export function isMoment(value: unknown): value is Moment {
  * @param allowDeletion  if true, delete property in a if explicitly set to null in b
  */
 function copyOrDelete(a: any, b: any, prop: string, allowDeletion: boolean): void {
+  console.warn(`vis-util.copyOrDelete is deprecated and will be removed in the next major release`);
   let doDeletion = false
   if (allowDeletion === true) {
     doDeletion = b[prop] === null && a[prop] !== undefined

--- a/src/util.ts
+++ b/src/util.ts
@@ -563,11 +563,14 @@ export function convert(object: unknown, type: Types | null): any {
 /**
  * Get the type of an object, for example exports.getType([]) returns 'Array'
  *
+ * @deprecated
+ *
  * @param object - Input value of unknown type.
  *
  * @returns Detected type.
  */
 export function getType(object: unknown): string {
+  console.warn(`vis-util.getType is deprecated and will be removed in the next major release`);
   const type = typeof object
 
   if (type === 'object') {


### PR DESCRIPTION
These functions are not used in any package of the visjs family:
- copyOrDelete (used only internally)
- isMoment( used only internally; should be replaced with the native `moment.isMoment`)
- getType (used only internally)
- RGBtoHex (used only internally)

I marked them as `deprecated`. They now show a` console.warn` if called.