### PR TITLE
style: remove Prettier parser

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,3 +1,1 @@
-{
-  "parser": "typescript"
-}
+{}


### PR DESCRIPTION
Prettier seems to understand the difference between .js, .ts etc.
Maybe this can solve some issues (like the conversion from Yaml to gibberish with PrettierCI)?

PS: We need this config even if it is completely empty to override ~/.prettierrc.json.