### PR TITLE
fix(build): extend other Vis libraries

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -28,6 +28,7 @@ export default [
       file: 'dist/umd.js',
       format: 'umd',
       name: 'vis',
+      extend: true
     },
     plugins: [resolve(resolveConfig), commonjs(), babel(babelConfingBase)],
   },


### PR DESCRIPTION
They were overwritten before which resulted in only one Vis library being usable at a time.

Addresses: https://github.com/visjs/vis-network/issues/66.