### PR TITLE
fix: use core-js 2 for the time being

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,7 +5,7 @@
       {
         "targets": "> 0.1% or not dead",
         "useBuiltIns": "usage",
-        "corejs": 3
+        "corejs": 2
       }
     ],
     "@babel/preset-typescript"

--- a/package-lock.json
+++ b/package-lock.json
@@ -807,6 +807,14 @@
         "mkdirp": "^0.5.1",
         "pirates": "^4.0.0",
         "source-map-support": "^0.5.9"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.2.1.tgz",
+          "integrity": "sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw==",
+          "dev": true
+        }
       }
     },
     "@babel/template": {
@@ -2863,9 +2871,9 @@
       }
     },
     "core-js": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.1.4.tgz",
-      "integrity": "sha512-YNZN8lt82XIMLnLirj9MhKDFZHalwzzrL9YLt6eb0T5D0EDl4IQ90IGkua8mHbnxNrkj1d8hbdizMc0Qmg1WnQ==",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+      "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
       "dev": true
     },
     "core-js-compat": {

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "assert": "^2.0.0",
     "babel-plugin-istanbul": "^5.1.4",
     "chai": "^4.2.0",
+    "core-js": "^2.6.9",
     "eslint": "^6.0.1",
     "eslint-config-prettier": "^6.0.0",
     "eslint-plugin-prettier": "^3.1.0",


### PR DESCRIPTION
Resolves issues with rollup-plugin-babel-minify.

Addresses https://github.com/visjs/vis-network/issues/72.