### PR TITLE
fix: don't use Object.getPrototypeOf on primitives

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -388,11 +388,16 @@ export function deepExtend(
 ): any {
   for (const prop in b) {
     if (Object.prototype.hasOwnProperty.call(b, prop) || protoExtend === true) {
-      if (b[prop] && Object.getPrototypeOf(b[prop]) === Object.prototype) {
+      if (
+        typeof b[prop] === "object" &&
+        b[prop] !== null &&
+        Object.getPrototypeOf(b[prop]) === Object.prototype
+      ) {
         if (a[prop] === undefined) {
           a[prop] = deepExtend({}, b[prop], protoExtend); // NOTE: allowDeletion not propagated!
         } else if (
-          a[prop] &&
+          typeof a[prop] === "object" &&
+          a[prop] !== null &&
           Object.getPrototypeOf(a[prop]) === Object.prototype
         ) {
           deepExtend(a[prop], b[prop], protoExtend); // NOTE: allowDeletion not propagated!


### PR DESCRIPTION
The specification changed to allow this but there doesn't seem to be a polyfill for IE11 which isn't updated anymore.

A part of solution to https://github.com/visjs/vis-network/issues/57 issue.