### PR TITLE
chore(deps): pin runtime dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,8 +67,8 @@
     "LICENSE*"
   ],
   "dependencies": {
-    "moment": "^2.24.0",
-    "vis-uuid": "^1.1.3"
+    "moment": "2.24.0",
+    "vis-uuid": "1.1.3"
   },
   "devDependencies": {
     "@babel/core": "^7.5.5",


### PR DESCRIPTION
Greenkeeper doesn't open a PR when the new version satisfies the range and works. Therefore we receive issues if something breaks and PRs for breaking changes but not for features or fixes. This will make Greenkeeper open a PR for every release.