### PR TITLE
fix(build): resolve compatibility issues with IE11

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,7 +3,10 @@
     [
       "@babel/preset-env",
       {
-        "targets": "> 0.1% or not dead",
+        "targets": {
+          "browsers": "> 0.1% or not dead",
+          "esmodules": false
+        },
         "useBuiltIns": false
       }
     ],

--- a/.babelrc
+++ b/.babelrc
@@ -19,10 +19,7 @@
       }
     ]
   ],
-  "exclude": [
-    "node_modules/@babel/runtime-corejs3/**",
-    "node_modules/core-js-pure/**"
-  ],
+  "exclude": ["**/node_modules/**"],
   "env": {
     "test": {
       "presets": [


### PR DESCRIPTION
This should finally resolve the issues with IE11. Long story short we were polyfilling polyfills which resulted in all kinds of weird issues. This PR makes all bundles IE11 compatible so there's no need to transpile them anymore. Everything can be simply bundled and should work without issues. It should also somewhat reduce bundle size as there will be only a single layer of polyfilling done.