### PR TITLE
chore(package): fix src dir pollution and clean script

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "build:code": "rollup -c rollup.build.js",
     "build:docs": "typedoc ./src",
     "build:types": "tsc -p tsconfig.types.json",
-    "clean": "rimraf '{coverage,docs,esm,reports,types,umd}' 'index.{d.ts,js}'",
+    "clean": "rimraf '{coverage,declarations,docs,esnext,peer,reports,standalone}' 'index.{d.ts,js}'",
     "lint": "eslint '{src,test}/**/*.{m,}{j,t}s{x,}'",
     "lint:fix": "npm run lint -- --fix",
     "prepublishOnly": "npm run build",

--- a/rollup.build.js
+++ b/rollup.build.js
@@ -6,5 +6,5 @@ export default generateRollupConfiguration({
   libraryFilename: "vis-util",
   entryPoint: "./src",
   packageJSON,
-  tsconfig: "tsconfig.json"
+  tsconfig: "tsconfig.code.json"
 });

--- a/tsconfig.code.json
+++ b/tsconfig.code.json
@@ -1,0 +1,8 @@
+{
+    "extends": "./tsconfig",
+    "compilerOptions": {
+        "declaration": false,
+        "declarationMap": false
+    },
+    "exclude": ["test"]
+}


### PR DESCRIPTION
Declarations were accidentally generated not only into declarations dir but also into src dir next to each source JS file. This PR prevents this kind of pollution.

The clean script wasn't updated when we unified the package format. Now it deletes the files that are actually built and no longer tries to delete files that are not being created anymore.