### PR TITLE
test(exports): update the test

### DIFF
--- a/__snapshots__/test/package.test.ts.js
+++ b/__snapshots__/test/package.test.ts.js
@@ -4,6 +4,8 @@ exports['Package Exported files 1'] = {
     "        LICENSE-APACHE-2.0",
     "        LICENSE-MIT",
     "        README.md",
+    "        declarations/deep-object-assign.d.ts",
+    "        declarations/deep-object-assign.d.ts.map",
     "        declarations/entry-esnext.d.ts",
     "        declarations/entry-esnext.d.ts.map",
     "        declarations/entry-peer.d.ts",


### PR DESCRIPTION
This happened because the deep object assign was created before the package exports test was merged and therefore didn't come with an update to the snapshot and CI didn't catch it (I have no idea why because require up to date is enabled in the settings of the repo).