### PR TITLE
style(eslint): allow require in config files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -73,6 +73,16 @@ module.exports = {
     // Reports typeof bigint as an error, tsc validates this anyway so no problem turning this off.
     "valid-typeof": "off",
   },
+  overrides: [
+    // Config files
+    {
+      files: ["./*.js"],
+      rules: {
+        // Config files may not be transpiled, don't report the use of require.
+        "@typescript-eslint/no-var-requires": "off",
+      },
+    },
+  ],
   settings: {
     jsdoc: {
       mode: "typescript",


### PR DESCRIPTION
Config files are generally not transpiled, so using require may be the only available way.

This will unblock update to TS ESLint 3.2 (#346).