### PR TITLE
changed readonly array syntax to support older tsc

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -471,9 +471,9 @@ export function getType(object: unknown): string {
   return type;
 }
 
-export function copyAndExtendArray<T>(arr: readonly T[], newValue: T): T[];
+export function copyAndExtendArray<T>(arr: ReadonlyArray<T>, newValue: T): T[];
 export function copyAndExtendArray<A, V>(
-  arr: readonly A[],
+  arr: ReadonlyArray<A>,
   newValue: V
 ): (A | V)[];
 /**
@@ -485,7 +485,7 @@ export function copyAndExtendArray<A, V>(
  * @returns A new array with all items from arr and newValue (which is last).
  */
 export function copyAndExtendArray<A, V>(
-  arr: readonly A[],
+  arr: ReadonlyArray<A>,
   newValue: V
 ): (A | V)[] {
   return [...arr, newValue];


### PR DESCRIPTION
`readonly T[]` is new syntax for `ReadonlyArray<T>` which is supported in typescript older than 3.4.
As of now everything works but throws error while compiling in angular 7. 
Please review and let me know if it is acceptable.
Thanks 