### PR TITLE
fix(deep-object-assign): remove and prohibit console.log()

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -51,6 +51,9 @@ module.exports = {
       },
     ],
 
+    // Disable console log.
+    "no-console": ["error", { allow: ["info", "warn", "error"] }],
+
     // This would be a breaking change for little gain. Though there definitely
     // is some merit in this.
     "@typescript-eslint/ban-types": "off",

--- a/src/deep-object-assign.ts
+++ b/src/deep-object-assign.ts
@@ -55,7 +55,6 @@ export function deepObjectAssign<T>(target: T, ...sources: Assignable<T>[]): T;
 export function deepObjectAssign(...values: readonly any[]): any {
   const merged = deepObjectAssignNonentry(...values);
   stripDelete(merged);
-  console.log(merged);
   return merged;
 }
 


### PR DESCRIPTION
I personally use `console.log()` only for debugging purposes and that's what it was used for in this case. However somehow it got released though and pollutes the console in production.

This removes it from `deepObjectAssign()` and adds an ESLint rule to prevent this from happening again.