### PR TITLE
fix(deep-object-assign): enumarability check

### DIFF
--- a/src/deep-object-assign.ts
+++ b/src/deep-object-assign.ts
@@ -82,7 +82,7 @@ function deepObjectAssignNonentry(...values: readonly any[]): any {
   const b = values[1];
 
   for (const prop of Reflect.ownKeys(b)) {
-    if (Object.prototype.propertyIsEnumerable.call(b, b[prop])) {
+    if (!Object.prototype.propertyIsEnumerable.call(b, prop)) {
       // Ignore nonenumerable props, Object.assign() would do the same.
     } else if (b[prop] === DELETE) {
       delete a[prop];

--- a/test/deep-object-assign.test.ts
+++ b/test/deep-object-assign.test.ts
@@ -245,4 +245,9 @@ test(deepObjectAssign, (): void => {
     id: 0.25,
     [SYMBOL_KEY]: 2,
   });
+
+  given({}, { foo: "bar", deleteFoo: "foo" }).expect({
+    foo: "bar",
+    deleteFoo: "foo",
+  });
 });


### PR DESCRIPTION
This was a really dumb error. Instead of testing whether the object has enumerable prop by it's key it used the value of the prop (checking the enumerability of completely different prop) and skipped assigning if so.

Closes https://github.com/visjs/vis-data/issues/384.