### PR TITLE
chore(deps): rewrite Rollup cmd to support v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "scripts": {
     "build": "run-s build:types build:code build:docs",
-    "build:code": "rollup -c rollup.build.js",
+    "build:code": "rollup --bundleConfigAsCjs --config rollup.build.js",
     "build:docs": "typedoc",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "rimraf '{coverage,declarations,docs,esnext,peer,reports,standalone}' 'index.{d.ts,js}'",


### PR DESCRIPTION
This will show some warnings with v2 but otherwise does nothing, it's required with v3 to work without rewriting the module system used in the config file.