### PR TITLE
fix(css): use native element to properly parse CSS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@egjs/hammerjs": "2.0.17",
         "@types/chai": "4.3.6",
+        "@types/jsdom-global": "^3.0.4",
         "@types/mocha": "10.0.1",
         "@types/node": "18.15.12",
         "@types/sinon": "10.0.16",
@@ -3832,6 +3833,26 @@
       "integrity": "sha512-ewXv/ceBaJprikMcxCmWU1FKyMAQ2X7a9Gtmzw8fcg2kIePI1crERDM818W+XYrxqdBBOdlf2rm137bU+BltCA==",
       "dev": true
     },
+    "node_modules/@types/jsdom": {
+      "version": "21.1.2",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.2.tgz",
+      "integrity": "sha512-bGj+7TaCkOwkJfx7HtS9p22Ij0A2aKMuz8a1+owpkxa1wU/HUBy/WAXhdv90uDdVI9rSjGvUrXmLSeA9VP3JeA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
+      }
+    },
+    "node_modules/@types/jsdom-global": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/jsdom-global/-/jsdom-global-3.0.4.tgz",
+      "integrity": "sha512-7QAKHPEVcNvEPpHhGWwN9rRs+JTraZXXRatkud/TD2Zm8p9nO6Y8462lcOmgu6FHho20TkjbxP4qra8MzYL9HA==",
+      "dev": true,
+      "dependencies": {
+        "@types/jsdom": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -3890,6 +3911,12 @@
       "version": "8.1.2",
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.2.tgz",
       "integrity": "sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA==",
+      "dev": true
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.3.tgz",
+      "integrity": "sha512-THo502dA5PzG/sfQH+42Lw3fvmYkceefOspdCwpHRul8ik2Jv1K8I5OZz1AT3/rs46kwgMCe9bSBmDLYkkOMGg==",
       "dev": true
     },
     "node_modules/@types/unist": {

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
   "devDependencies": {
     "@egjs/hammerjs": "2.0.17",
     "@types/chai": "4.3.6",
+    "@types/jsdom-global": "^3.0.4",
     "@types/mocha": "10.0.1",
     "@types/node": "18.15.12",
     "@types/sinon": "10.0.16",

--- a/src/util.ts
+++ b/src/util.ts
@@ -1155,32 +1155,28 @@ export function RGBToHSV(red: number, green: number, blue: number): HSV {
 interface CSSStyles {
   [key: string]: string;
 }
-const cssUtil = {
-  // split a string with css styles into an object with key/values
-  split(cssText: string): CSSStyles {
-    const styles: CSSStyles = {};
 
-    cssText.split(";").forEach((style): void => {
-      if (style.trim() != "") {
-        const parts = style.split(":");
-        const key = parts[0].trim();
-        const value = parts[1].trim();
-        styles[key] = value;
-      }
-    });
+/**
+ * Split a string with css styles into an object with key/values.
+ *
+ * @param cssText - CSS source code to split into key/value object.
+ * @returns Key/value object corresponding to {@link cssText}.
+ */
+function splitCSSText(cssText: string): CSSStyles {
+  const tmpEllement = document.createElement("div");
 
-    return styles;
-  },
+  const styles: CSSStyles = {};
 
-  // build a css text string from an object with key/values
-  join(styles: CSSStyles): string {
-    return Object.keys(styles)
-      .map(function (key): string {
-        return key + ": " + styles[key];
-      })
-      .join("; ");
-  },
-};
+  tmpEllement.style.cssText = cssText;
+
+  for (let i = 0; i < tmpEllement.style.length; ++i) {
+    styles[tmpEllement.style[i]] = tmpEllement.style.getPropertyValue(
+      tmpEllement.style[i]
+    );
+  }
+
+  return styles;
+}
 
 /**
  * Append a string with css styles to an element.
@@ -1189,14 +1185,10 @@ const cssUtil = {
  * @param cssText - The styles to be appended.
  */
 export function addCssText(element: HTMLElement, cssText: string): void {
-  const currentStyles = cssUtil.split(element.style.cssText);
-  const newStyles = cssUtil.split(cssText);
-  const styles = {
-    ...currentStyles,
-    ...newStyles,
-  };
-
-  element.style.cssText = cssUtil.join(styles);
+  const cssStyle = splitCSSText(cssText);
+  for (const [key, value] of Object.entries(cssStyle)) {
+    element.style.setProperty(key, value);
+  }
 }
 
 /**
@@ -1206,16 +1198,10 @@ export function addCssText(element: HTMLElement, cssText: string): void {
  * @param cssText - The styles to be removed.
  */
 export function removeCssText(element: HTMLElement, cssText: string): void {
-  const styles = cssUtil.split(element.style.cssText);
-  const removeStyles = cssUtil.split(cssText);
-
-  for (const key in removeStyles) {
-    if (Object.prototype.hasOwnProperty.call(removeStyles, key)) {
-      delete styles[key];
-    }
+  const cssStyle = splitCSSText(cssText);
+  for (const key of Object.keys(cssStyle)) {
+    element.style.removeProperty(key);
   }
-
-  element.style.cssText = cssUtil.join(styles);
 }
 
 /**

--- a/test/add-css-text.test.ts
+++ b/test/add-css-text.test.ts
@@ -1,0 +1,67 @@
+import jsdom_global from "jsdom-global";
+import { expect } from "chai";
+
+import { addCssText } from "../src";
+
+describe("addCssText", function (): void {
+  beforeEach(function () {
+    this.jsdom_global = jsdom_global();
+  });
+
+  afterEach(function () {
+    this.jsdom_global();
+  });
+
+  it("Add color and background URL to nothing", function (): void {
+    const element = document.createElement("div");
+    element.style.cssText = "";
+
+    addCssText(
+      element,
+      "color: blue; background: url(http://www.example.com:8080/b.jpg);"
+    );
+
+    expect(element.style.cssText).to.equal(
+      "color: blue; background: url(http://www.example.com:8080/b.jpg);"
+    );
+  });
+
+  it("Add nothing to color, margin and background URL", function (): void {
+    const element = document.createElement("div");
+    element.style.cssText =
+      "color: red; margin: 1em; background: url(http://www.example.com:8080/a.jpg);";
+
+    addCssText(element, "");
+
+    expect(element.style.cssText).to.equal(
+      "color: red; margin: 1em; background: url(http://www.example.com:8080/a.jpg);"
+    );
+  });
+
+  it("Add padding to color, margin and background URL", function (): void {
+    const element = document.createElement("div");
+    element.style.cssText =
+      "color: red; margin: 1em; background: url(http://www.example.com:8080/a.jpg);";
+
+    addCssText(element, "padding: 4ex;");
+
+    expect(element.style.cssText).to.equal(
+      "color: red; margin: 1em; background: url(http://www.example.com:8080/a.jpg); padding: 4ex;"
+    );
+  });
+
+  it("Add color and background URL to color, margin and background URL", function (): void {
+    const element = document.createElement("div");
+    element.style.cssText =
+      "color: red; margin: 1em; background: url(http://www.example.com:8080/a.jpg);";
+
+    addCssText(
+      element,
+      "color: blue; background: url(http://www.example.com:8080/b.jpg);"
+    );
+
+    expect(element.style.cssText).to.equal(
+      "color: blue; margin: 1em; background: url(http://www.example.com:8080/b.jpg);"
+    );
+  });
+});

--- a/test/bridge-object.test.ts
+++ b/test/bridge-object.test.ts
@@ -1,8 +1,17 @@
+import jsdom_global from "jsdom-global";
 import { expect } from "chai";
 
 import { bridgeObject } from "../src";
 
 describe("bridgeObject", function (): void {
+  beforeEach(function () {
+    this.jsdom_global = jsdom_global();
+  });
+
+  afterEach(function () {
+    this.jsdom_global();
+  });
+
   describe("Invalid input", function (): void {
     [
       null,

--- a/test/remove-css-text.test.ts
+++ b/test/remove-css-text.test.ts
@@ -1,0 +1,63 @@
+import jsdom_global from "jsdom-global";
+import { expect } from "chai";
+
+import { removeCssText } from "../src";
+
+describe("removeCssText", function (): void {
+  beforeEach(function () {
+    this.jsdom_global = jsdom_global();
+  });
+
+  afterEach(function () {
+    this.jsdom_global();
+  });
+
+  it("Remove color and background URL from nothing", function (): void {
+    const element = document.createElement("div");
+    element.style.cssText = "";
+
+    removeCssText(
+      element,
+      "color: blue; background: url(http://www.example.com:8080/b.jpg);"
+    );
+
+    expect(element.style.cssText).to.equal("");
+  });
+
+  it("Remove nothing from color, margin and background URL", function (): void {
+    const element = document.createElement("div");
+    element.style.cssText =
+      "color: red; margin: 1em; background: url(http://www.example.com:8080/a.jpg);";
+
+    removeCssText(element, "");
+
+    expect(element.style.cssText).to.equal(
+      "color: red; margin: 1em; background: url(http://www.example.com:8080/a.jpg);"
+    );
+  });
+
+  it("Remove padding from color, margin and background URL", function (): void {
+    const element = document.createElement("div");
+    element.style.cssText =
+      "color: red; margin: 1em; background: url(http://www.example.com:8080/a.jpg);";
+
+    removeCssText(element, "padding: 4ex;");
+
+    expect(element.style.cssText).to.equal(
+      "color: red; margin: 1em; background: url(http://www.example.com:8080/a.jpg);"
+    );
+  });
+
+  it("Remove color and background URL from color, margin and background URL", function (): void {
+    const element = document.createElement("div");
+    element.style.cssText =
+      "color: red; margin: 1em; background: url(http://www.example.com:8080/a.jpg);";
+
+    removeCssText(
+      element,
+      "color: blue; background: url(http://www.example.com:8080/b.jpg);"
+    );
+
+    expect(element.style.cssText).to.equal("margin: 1em;");
+  });
+});

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -817,6 +817,10 @@ describe("util", function () {
       this.defaultValue = document.createElement("div");
     });
 
+    after(function () {
+      this.jsdom_global();
+    });
+
     it("resolves value from a function", function () {
       var me = this;
       assert.equal(


### PR DESCRIPTION
This addresses cases such as #1368 where more complex CSS crashed the original rudimentary implementation.

Unit test coverage has also been slightly increased as the altered code is tested now.