### PR TITLE
chore(typescript): remove global hammerjs types

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,8 +15,7 @@
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
-    "target": "esnext",
-    "types": ["hammerjs"]
+    "target": "esnext"
   },
   "exclude": ["node_modules", "**/__tests__/*"],
   "include": ["src", "test"]


### PR DESCRIPTION
We import explicitly from @egjs/hammerjs both types and values.